### PR TITLE
Remove unused dependencies from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ repositories {
 }
 
 dependencies {
-    implementation depsArray.lang3
-    implementation depsArray.json
 }
 
 tasks.withType(JavaCompile) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,5 @@ ext {
     spotbugsVersion = '6.0.27'
 
     depsArray = [
-            lang3: 'org.apache.commons:commons-lang3:3.17.0',
-            json : 'org.json:json:20241224',
     ]
 }


### PR DESCRIPTION
Remove the implementation of `depsArray.lang3` and `depsArray.json` from the repository.

* **build.gradle**
  - Remove the line `implementation depsArray.lang3` from the `dependencies` section.
  - Remove the line `implementation depsArray.json` from the `dependencies` section.

* **dependencies.gradle**
  - Remove the line `lang3: 'org.apache.commons:commons-lang3:3.17.0'` from the `depsArray` map.
  - Remove the line `json : 'org.json:json:20241224'` from the `depsArray` map.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tgrothe/java-linear-git-history/pull/8?shareId=8dca7c38-3dc4-4aaf-aadf-eeb2c1bb96cd).